### PR TITLE
ENHANCE: Add start limit interval

### DIFF
--- a/pkgs/mkService.nix
+++ b/pkgs/mkService.nix
@@ -21,6 +21,7 @@
 , additionalWriteDirs ? []
 , permitNewPrivileges ? false
 , killMode ? "control-group"
+, startLimitIntervalSec ? "20s"
 , exports ? {}
 }@attrs:
 
@@ -67,6 +68,7 @@ let
       else if restartOnSuccess
         then "on-success"
       else   "no";
+    StartLimitInterval = startLimitIntervalSec;
   } // lib.optionalAttrs (execStartPre != "") { ExecStartPre = execStartPre; }
     // lib.optionalAttrs (execStartPost != "") { ExecStartPost = execStartPost; }
     // lib.optionalAttrs (!network) { PrivateNetwork = "yes"; }


### PR DESCRIPTION
@rimmington @dwillie
This will add a common service attribute `StartLimitInterval` with a default of 20 seconds. This is to get around services failing to slowly to hit the start-limit on the pi