### PR TITLE
FIX: Return false for error code 4

### DIFF
--- a/overlay/disquick/disctl/src/main.rs
+++ b/overlay/disquick/disctl/src/main.rs
@@ -129,7 +129,7 @@ fn run<T>(cmd: &mut Command) -> Result<T> where T : CommandOut {
 fn disnix_running() -> Result<bool> {
     match run(Command::new("systemctl").arg("status").arg("disnix.service")) {
         Ok(Suppress) => Ok(true),
-        Err(NonZero(Some(code))) if code == 3 => Ok(false),
+        Err(NonZero(Some(code))) if code == 3 || code == 4 => Ok(false),
         Err(e) => Err(e)
     }
 }


### PR DESCRIPTION
@rodney and I went on a goose hunt:
- Fixes disctl not running systemctl commands when the status of the disnix service was unknown (error code 4) since update of systemd/systemctl
- Provided a link to the commit that adds the error code:
https://github.com/systemd/systemd/commit/ca473d572f0d2d8f547ff787ae67afd489a3f15e